### PR TITLE
Fix AWS provider 6.x compatibility

### DIFF
--- a/modules/computation/batch.tf
+++ b/modules/computation/batch.tf
@@ -1,12 +1,11 @@
 resource "aws_batch_compute_environment" "this" {
   /* Unique name for compute environment.
-     We use compute_environment_name_prefix opposed to just compute_environment_name as batch compute environments must
-     be created and destroyed, never edited. This way when we go to make a "modification" we will stand up a new
-     batch compute environment with a new unique name and once that succeeds, the old one will be torn down. If we had
-     just used compute_environment_name, then there would be a conflict when we went to stand up the new
-     compute_environment that had the modifications applied and the process would fail.
+     We use compute_environment_name opposed to compute_environment_name_prefix (deprecated in AWS provider 6.x) 
+     as batch compute environments must be created and destroyed, never edited. This way when we go to make a 
+     "modification" we will stand up a new batch compute environment and once that succeeds, the old one will be 
+     torn down via the create_before_destroy lifecycle rule.
   */
-  compute_environment_name_prefix = local.compute_env_prefix_name
+  compute_environment_name = local.compute_env_prefix_name
 
   # Give permissions so the batch service can make API calls.
   service_role = aws_iam_role.batch_execution_role.arn


### PR DESCRIPTION
## Summary

Fixes AWS provider 6.x compatibility by replacing the deprecated `compute_environment_name_prefix` argument with `compute_environment_name`.

## Changes

- Replace `compute_environment_name_prefix` with `compute_environment_name` in `modules/computation/batch.tf`
- Update comments to reflect the change

## Background

AWS provider 6.x removed the `compute_environment_name_prefix` argument from `aws_batch_compute_environment`. The existing `create_before_destroy` lifecycle rule will handle recreation when modifications are needed, so using a static name is safe.

## Related

- Needed for DE-2190: Upgrade data workspace to AWS provider 6.x

## Test Plan

- Terraform plan should succeed with AWS provider >= 6.24.0
- Batch compute environments should continue to be recreated (not modified in-place) due to the `create_before_destroy` lifecycle rule