### PR TITLE
RT-8057 Add extra_metadata_service_env_vars to metadata service ECS task

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -46,6 +46,8 @@ module "metaflow-metadata-service" {
   vpc_cidr_blocks                  = var.vpc_cidr_blocks
   with_public_ip                   = var.with_public_ip
 
+  extra_metadata_service_env_vars = var.extra_metadata_service_env_vars
+
   standard_tags = var.tags
 }
 

--- a/modules/metadata-service/ecs.tf
+++ b/modules/metadata-service/ecs.tf
@@ -13,43 +13,38 @@ resource "aws_ecs_cluster" "this" {
 resource "aws_ecs_task_definition" "this" {
   family = "${var.resource_prefix}service${var.resource_suffix}" # Unique name for task definition
 
-  container_definitions = <<EOF
-[
-  {
-    "name": "${var.resource_prefix}service${var.resource_suffix}",
-    "image": "${var.metadata_service_container_image}",
-    "essential": true,
-    "cpu": ${var.metadata_service_cpu},
-    "memory": ${var.metadata_service_memory},
-    "portMappings": [
-      {
-        "containerPort": 8080,
-        "hostPort": 8080
-      },
-      {
-        "containerPort": 8082,
-        "hostPort": 8082
-      }
-    ],
-    "environment": [
-      {"name": "MF_METADATA_DB_HOST", "value": "${replace(var.rds_master_instance_endpoint, ":5432", "")}"},
-      {"name": "MF_METADATA_DB_NAME", "value": "${var.database_name}"},
-      {"name": "MF_METADATA_DB_PORT", "value": "5432"},
-      {"name": "MF_METADATA_DB_PSWD", "value": "${var.database_password}"},
-      {"name": "MF_METADATA_DB_USER", "value": "${var.database_username}"},
-      {"name": "MF_METADATA_DB_SSL_MODE", "value": "${var.database_ssl_mode}"}
-    ],
-    "logConfiguration": {
-        "logDriver": "awslogs",
-        "options": {
-            "awslogs-group": "${aws_cloudwatch_log_group.this.name}",
-            "awslogs-region": "${data.aws_region.current.name}",
-            "awslogs-stream-prefix": "metadata"
+  container_definitions = jsonencode([
+    {
+      name      = "${var.resource_prefix}service${var.resource_suffix}"
+      image     = var.metadata_service_container_image
+      essential = true
+      cpu       = var.metadata_service_cpu
+      memory    = var.metadata_service_memory
+      portMappings = [
+        { containerPort = 8080, hostPort = 8080 },
+        { containerPort = 8082, hostPort = 8082 }
+      ]
+      environment = concat(
+        [
+          { name = "MF_METADATA_DB_HOST", value = replace(var.rds_master_instance_endpoint, ":5432", "") },
+          { name = "MF_METADATA_DB_NAME", value = var.database_name },
+          { name = "MF_METADATA_DB_PORT", value = "5432" },
+          { name = "MF_METADATA_DB_PSWD", value = var.database_password },
+          { name = "MF_METADATA_DB_USER", value = var.database_username },
+          { name = "MF_METADATA_DB_SSL_MODE", value = var.database_ssl_mode }
+        ],
+        [for k, v in var.extra_metadata_service_env_vars : { name = k, value = v }]
+      )
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          "awslogs-group"         = aws_cloudwatch_log_group.this.name
+          "awslogs-region"        = data.aws_region.current.name
+          "awslogs-stream-prefix" = "metadata"
         }
+      }
     }
-  }
-]
-EOF
+  ])
 
   network_mode             = "awsvpc"
   requires_compatibilities = ["FARGATE"]

--- a/modules/metadata-service/variables.tf
+++ b/modules/metadata-service/variables.tf
@@ -138,3 +138,9 @@ variable "with_public_ip" {
   type        = bool
   description = "Enable public IP assignment for the Metadata Service. Typically you want this to be set to true if using public subnets as subnet1_id and subnet2_id, and false otherwise"
 }
+
+variable "extra_metadata_service_env_vars" {
+  type        = map(string)
+  default     = {}
+  description = "Additional environment variables for the metadata service container"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -201,6 +201,12 @@ variable "extra_ui_static_env_vars" {
   description = "Additional environment variables for UI static app"
 }
 
+variable "extra_metadata_service_env_vars" {
+  type        = map(string)
+  default     = {}
+  description = "Additional environment variables for the metadata service container"
+}
+
 variable "with_public_ip" {
   type        = bool
   description = "Enable public IP assignment for the Metadata Service. If the subnets specified for subnet1_id and subnet2_id are public subnets, you will NEED to set this to true to allow pulling container images from public registries. Otherwise this should be set to false."


### PR DESCRIPTION
## Summary

- Adds `extra_metadata_service_env_vars` variable (map of string) to the metadata service module, allowing callers to pass arbitrary env vars to the ECS task definition
- Migrates the ECS task definition `container_definitions` from a heredoc to `jsonencode` for cleaner variable interpolation
- Wires the variable through from root `variables.tf` → `main.tf` → `modules/metadata-service`

Needed to set `MF_METADATA_DB_POOL_MAX=50` in tf-restricted-workspaces to address intermittent 500 errors on the Metaflow metadata service during nightly InferenceFlow runs (RT-8057).