### PR TITLE
PLA-12009: AWS provider v6 compatibility

### DIFF
--- a/modules/computation/batch.tf
+++ b/modules/computation/batch.tf
@@ -1,12 +1,13 @@
 resource "aws_batch_compute_environment" "this" {
   /* Unique name for compute environment.
-     We use compute_environment_name_prefix opposed to just compute_environment_name as batch compute environments must
+     We use name_prefix opposed to just name as batch compute environments must
      be created and destroyed, never edited. This way when we go to make a "modification" we will stand up a new
      batch compute environment with a new unique name and once that succeeds, the old one will be torn down. If we had
-     just used compute_environment_name, then there would be a conflict when we went to stand up the new
+     just used name, then there would be a conflict when we went to stand up the new
      compute_environment that had the modifications applied and the process would fail.
+     Note: in aws provider v6 the `compute_environment_name_prefix` argument was renamed to `name_prefix`.
   */
-  compute_environment_name_prefix = local.compute_env_prefix_name
+  name_prefix = local.compute_env_prefix_name
 
   # Give permissions so the batch service can make API calls.
   service_role = aws_iam_role.batch_execution_role.arn

--- a/modules/computation/versions.tf
+++ b/modules/computation/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.63.1, < 6.0.0"
+      version = ">= 5.63.1"
     }
   }
   required_version = ">= 1.4"

--- a/modules/datastore/versions.tf
+++ b/modules/datastore/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.63.1, < 6.0.0"
+      version = ">= 5.63.1"
     }
     random = {
       source = "hashicorp/random"

--- a/modules/metadata-service/versions.tf
+++ b/modules/metadata-service/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.63.1, < 6.0.0"
+      version = ">= 5.63.1"
     }
   }
   required_version = ">= 1.4"

--- a/modules/step-functions/versions.tf
+++ b/modules/step-functions/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.63.1, < 6.0.0"
+      version = ">= 5.63.1"
     }
   }
   required_version = ">= 1.4"

--- a/modules/ui/versions.tf
+++ b/modules/ui/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.63.1, < 6.0.0"
+      version = ">= 5.63.1"
     }
   }
   required_version = ">= 1.4"

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.63.1, < 6.0.0"
+      version = ">= 5.63.1"
     }
   }
   required_version = ">= 1.4"


### PR DESCRIPTION
## What

Makes the module compatible with AWS provider **v6** (validated against aws v6.50.0, `terraform validate` passes).

## Changes
- Relax the `aws` provider constraint in all `versions.tf` (root + 5 submodules) from `>= 5.63.1, < 6.0.0` to `>= 5.63.1`.
- `aws_batch_compute_environment`: rename `compute_environment_name_prefix` → **`name_prefix`** (the argument was renamed in aws v6). Using `name_prefix` (not `name`) preserves the existing random-suffix + create-before-destroy behaviour, so there is **no naming/recreate change** vs the v5 module.

## Why a fresh branch (not PR #12)
The earlier `fix/aws-provider-6x-compatibility` branch (PR #12, closed) was branched off stale history: it dropped `job_state_time_limit_actions`, removed `extra_metadata_service_env_vars`, and regressed `db_engine_version` (16→11) and `db_instance_type` defaults. This branch is built on the **current** pin `c7be58c` and changes nothing else.

## Audited but no change needed (already v6-clean)
- `aws_api_gateway_deployment` — already uses a separate `aws_api_gateway_stage` (no removed inline `stage_name`).
- `aws_db_instance` / `aws_rds_cluster` — no removed `character_set_name` combos.
- `aws_s3_bucket` — uses separate `aws_s3_bucket_acl` (no inline `acl`).

## Known non-blocking follow-up
`data.aws_region.current.name` is deprecated in v6 (use `.region`) — ~13 occurrences across 8 files. These are **warnings only** (removed in v7), left out to keep this change minimal. Worth a follow-up before v7.

Consumed by `tf-restricted-workspaces/data` (PLA-12009 aws v6 upgrade).