### PR TITLE
DE-2680: Pass through metadata_service_memory to submodule

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -39,6 +39,7 @@ module "metaflow-metadata-service" {
   iam_partition                    = var.iam_partition
   metadata_service_container_image = local.metadata_service_container_image
   metadata_service_cpu             = var.metadata_service_cpu
+  metadata_service_memory          = var.metadata_service_memory
   metadata_service_desired_count   = var.metadata_service_desired_count
   metaflow_vpc_id                  = var.vpc_id
   rds_master_instance_endpoint     = module.metaflow-datastore.rds_master_instance_endpoint

--- a/variables.tf
+++ b/variables.tf
@@ -114,6 +114,12 @@ variable "metadata_service_cpu" {
   description = "ECS task CPU units for metadata service"
 }
 
+variable "metadata_service_memory" {
+  type        = number
+  default     = 1024
+  description = "ECS task memory in MiB for metadata service"
+}
+
 variable "metadata_service_desired_count" {
   type        = number
   default     = 1


### PR DESCRIPTION
Fargate requires memory >= 2048 at 1024 CPU.